### PR TITLE
feat(cd): continuous deployment to integration for patch version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
-
-env:
-  GITHUB_TOKEN: ${{ secrets.WRITE_PACKAGES }}
+      - "v*.*.*-*"
 
 jobs:
   publish-jars:
@@ -43,15 +41,14 @@ jobs:
         pattern='^refs/tags/v[0-9]+\.[0-9]+\.(?:[1-9][0-9]*|[0-9]+-.*)$'
         echo "should_trigger_deploy=$([[ "$GITHUB_REF" =~ $pattern ]] && echo true || echo false)" >> $GITHUB_OUTPUT
   trigger-deploy:
-      name: Trigger Deploy
       needs: publish-docker-image
       if: needs.publish-docker-image.outputs.should_trigger_deploy == 'true'
       runs-on: ubuntu-latest
       steps:
-        - name: Extract tag without 'v' prefix
+        - name: tag without 'v' prefix
           id: extract_tag
           run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-        - name: Trigger deploy workflow in mvp-deployer
+        - name: trigger mvp-deployer workflow
           uses: peter-evans/repository-dispatch@v2
           with:
             token: ${{ secrets.RAW_CI_PAT }}


### PR DESCRIPTION
Automatically deploying fix/patch version

The logic is pretty basic since we follow semver. If the last part of the version is not ending with 0 then the update is a patch update
We add the possibility of having release candidates.
`-rc` or `-something` will also be automatically deployed to integration,

We take advantage of this pull request to remove useless `GITHUB_TOKEN` overwrite. 
by default `GITHUB_TOKEN` is set with read/write permissions (https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication)